### PR TITLE
chore: update Node.js to latest LTS

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -1,6 +1,6 @@
 name: "Cleanup Workspace"
 description: "This action will remove all files and directories from the root working directory."
 runs:
-  using: "node16"
+  using: "node20"
   main: "src/cleanup.js"
   post: "src/cleanup.js"


### PR DESCRIPTION
### What's Changed

Solves warning message:

```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: visable-dev/gh-action-cleanup-workspace@v1, actions/upload-artifact@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```
Example: https://github.com/visable-dev/wlw_styleguide/actions/runs/8093409937